### PR TITLE
added relative controller and CC midi channel support

### DIFF
--- a/edisyn/CCMap.java
+++ b/edisyn/CCMap.java
@@ -10,108 +10,56 @@ import java.io.*;
 import java.util.prefs.*;
 
 /**        
-           @author Sean Luke
+           @author Sean Luke       
 */
 
 public class CCMap
     {
     HashMap map = new HashMap();
     HashMap reverseMap = new HashMap();
+       
     
     Preferences prefs;
     
-    public Integer munge(int cc, int pane)
-        {
-        return Integer.valueOf((cc << 8) | pane);
-        }
-        
-    public int cc(Integer munge)
-        {
-        if (munge == null) return -1;
-        else return munge.intValue() >> 8;
-        }
-        
-    public int pane(Integer munge)
-        {
-        if (munge == null) return -1;
-        else return munge & 255;
-        }
-    
-    public String getKeyForCCPane(int cc, int pane)
-        {
-        return getKeyForInteger(munge(cc, pane));
-        }
-        
-    /** Returns the model key for the given CC value, or null if there is none. */
-    public String getKeyForInteger(Integer munge)
-        {
-        return (String)map.get(munge);
-        }
-        
-    /** Returns the model key for the given CC value, or null if there is none. */
-    public Integer getIntegerForKey(String key)
-        {
-        return (Integer)reverseMap.get(key);
-        }
-        
     public int getCCForKey(String key)
         {
-        return cc(getIntegerForKey(key));
-        }
-                
-    public int getPaneForKey(String key)
-        {
-        return pane(getIntegerForKey(key));
-        }
+    	String ckey = (String) reverseMap.get(key);
+    	if (ckey == null) return 0;
+    	String[] parts = ckey.split("_");
+    	
+    	return Integer.parseInt(parts[1]); // return cc value
+    	}
+
+    public String getKeyForCCChannelPane(int cc, int channel, int pane)
+    {
+    	String skey = ""+cc+"_"+channel+"_"+pane;
+		return (String) map.get(skey);
+	}
     
-    public void setKeyForCCPane(int cc, int pane, String key)
+    public void setKeyForCCChannelPane(int cc, int channel, int pane, String key)
         {
-        setKeyForInteger(munge(cc, pane), key);
-        }
-        
-    /** Sets the model key for the given CC value, and syncs the Preferences (which isn't cheap). */
-    public void setKeyForInteger(Integer munge, String key)
-        {
-        map.put(munge, key);
-        reverseMap.put(key, munge);
-                
-        prefs.put("" + munge.intValue(), key);
-        try 
-            {
-            prefs.sync();
-            }
-        catch (Exception ex)
-            {
-            ex.printStackTrace();
-            }
+    	String ckey = ""+cc+"_"+channel+"_"+pane;
+        map.put(ckey, key);
+        reverseMap.put(key, ckey);
+    	
+        prefs.put(ckey, key);
         }
     
     public CCMap(Preferences prefs)
         {
         this.prefs = prefs;
-        
-        // do a load
-        try
-            {
-            String[] keys = prefs.keys();
-            for(int i = 0; i < keys.length; i++)
-                {
-                // each Key holds a CC INTEGER
-                        
-                int munge = 0;
-                try { munge = Integer.parseInt(keys[i]); }
-                catch (Exception e) { e.printStackTrace(); }
-                        
-                // each Value holds a MODEL KEY STRING
-                        
-                map.put(Integer.valueOf(munge), prefs.get(keys[i], "-"));
-                reverseMap.put(prefs.get(keys[i], "-"), Integer.valueOf(munge));
-                }
-            }
+
+        try {	        
+	        for(String key : prefs.keys()) {
+	            map.put(key, prefs.get(key, "-"));
+	            reverseMap.put(prefs.get(key, "-"), key);	        	
+	        }
+        }
         catch (Exception ex)
-            {
-            ex.printStackTrace();
-            }
+        {
+        ex.printStackTrace();
+        }
+
         }
         
     public void clear()

--- a/edisyn/Model.java
+++ b/edisyn/Model.java
@@ -378,6 +378,27 @@ public class Model implements Cloneable
         set(key, value);
         }
     
+    public void setRelative(String key, int relChange)
+        {
+    	int value = get(key,0)+relChange;
+            
+	    if (minExists(key))
+	        {
+	        int min = getMin(key);
+	        if (get(key,0)+relChange < min)
+	            value = min;
+	        }
+	            
+	    if (maxExists(key))
+	        {
+	        int max = getMax(key);
+	        if (get(key,0)+relChange  > max)
+	            value = max;
+	        }
+	    
+	    set(key, value);
+	    }
+
     public void updateListenersForKey(String key)
         {
         ArrayList list = (ArrayList)(listeners.get(key));

--- a/edisyn/Synth.java
+++ b/edisyn/Synth.java
@@ -1845,21 +1845,20 @@ public abstract class Synth extends JComponent implements Updatable
         
     public void handleCC(ShortMessage message)
         {
-    	boolean relcc = true; // fixed relative cc (x..64..y) usage - replace with information from GUI/model
+    	boolean relcc = true; // fixed relative cc (x..64..y) usage - replace with config information from GUI/model
         lastCC = message.getData1();
-        // System.out.println("cc message channel: "+message.getChannel());
         if (learning)
             {
             String key = model.getLastKey();
             if (key != null)
                 {
-                ccmap.setKeyForCCPane(lastCC, getCurrentTab(), key);
+                ccmap.setKeyForCCChannelPane(lastCC, message.getChannel(), getCurrentTab(), key);
                 toggleLearning();  // we're done
                 }
             }
         else
             {
-            String key = ccmap.getKeyForCCPane(lastCC, getCurrentTab());
+            String key = ccmap.getKeyForCCChannelPane(lastCC,  message.getChannel(), getCurrentTab());
             int val = message.getData2();
             if (key != null)
                 {

--- a/edisyn/Synth.java
+++ b/edisyn/Synth.java
@@ -1845,7 +1845,9 @@ public abstract class Synth extends JComponent implements Updatable
         
     public void handleCC(ShortMessage message)
         {
+    	boolean relcc = true; // fixed relative cc (x..64..y) usage - replace with information from GUI/model
         lastCC = message.getData1();
+        // System.out.println("cc message channel: "+message.getChannel());
         if (learning)
             {
             String key = model.getLastKey();
@@ -1861,15 +1863,26 @@ public abstract class Synth extends JComponent implements Updatable
             int val = message.getData2();
             if (key != null)
                 {
-                if (model.minExists(key))
-                    {
-                    val += model.getMin(key);
-                    }
-                else if (model.maxExists(key))
-                    {
-                    val = val - 127 + model.getMax(key);
-                    }
-                model.setBounded(key, val);
+            	if (relcc) { // use relative values centered around CC=64
+	            	if (model.minExists(key))
+	                {
+	            		if (val < 64) { 
+	            		model.setRelative(key,-(64-val));
+	            		}
+	            		
+	            		if (val > 64) model.setRelative(key,val-64);
+	                }
+            	} else { // using absolute (0..127) values
+	                if (model.minExists(key))
+	                    {
+	                    val += model.getMin(key);
+	                    }
+	                else if (model.maxExists(key))
+	                    {
+	                    val = val - 127 + model.getMax(key);
+	                    }
+	                model.setBounded(key, val);
+	                }
                 }
             }
         }


### PR DESCRIPTION
support was added for relative controllers (centered around value 64). this is currently hardcoded and would need handling in the gui for changing from absolute (0..127) to relative (smaller<64<larger) controller handling. probably configurable for midi controller names.
relative controllers elegantly avoid the problem with value ranges and knob state after program load.

support was added  for handling midi channels of CC. now 127*16 knobs can be used instead of 127.

I have tested both changes with a Blofeld and Arturia BeatStep and it works for me. 

please be aware that your repository does not contain all source codes (f.e. edisyn.gui.PatchDisplay is missing). i was not able to compile and build a complete jar from source. classpath trickery is needed to load my patched classes before your jar. also your repo has no build or project files.

