### PR TITLE
Use Service Provider Interfaces to load synths

### DIFF
--- a/edisyn/Synth.java
+++ b/edisyn/Synth.java
@@ -381,42 +381,8 @@ public abstract class Synth extends JComponent implements Updatable
     //////// SYNTHESIZER EDIT PANES
         
     /** All synthesizer editor pane classes in Edisyn */
-    public static final Class[] synths = new Class[] 
-    { 
-    //edisyn.synth.futuresonusparva.FuturesonusParva.class,
-    //edisyn.synth.generic.Generic.class,
-    //edisyn.synth.casiocz.CasioCZ.class,
-    edisyn.synth.dsiprophet08.DSIProphet08.class,
-    edisyn.synth.emumorpheus.EmuMorpheus.class,
-    edisyn.synth.emumorpheus.EmuMorpheusHyper.class,
-    edisyn.synth.emumorpheus.EmuMorpheusMap.class,
-    edisyn.synth.kawaik1.KawaiK1.class, 
-    edisyn.synth.kawaik1.KawaiK1Multi.class, 
-    edisyn.synth.kawaik4.KawaiK4.class, 
-    edisyn.synth.kawaik4.KawaiK4Multi.class, 
-    edisyn.synth.kawaik4.KawaiK4Drum.class,
-    edisyn.synth.kawaik4.KawaiK4Effect.class,
-    edisyn.synth.kawaik5.KawaiK5.class,
-    edisyn.synth.korgmicrokorg.KorgMicroKorg.class,
-    edisyn.synth.korgmicrokorg.KorgMicroKorgVocoder.class,
-    edisyn.synth.korgmicrosampler.KorgMicrosampler.class,
-    edisyn.synth.korgsg.KorgSG.class,
-    edisyn.synth.korgsg.KorgSGMulti.class,
-    edisyn.synth.korgwavestation.KorgWavestationPerformance.class,
-    edisyn.synth.korgwavestation.KorgWavestationPatch.class,
-    edisyn.synth.korgwavestation.KorgWavestationSequence.class,
-    //edisyn.synth.linnstrument.Linnstrument.class,
-    edisyn.synth.oberheimmatrix1000.OberheimMatrix1000.class, 
-    edisyn.synth.preenfm2.PreenFM2.class,
-   // edisyn.synth.rolandjv880.RolandJV880.class,
-    edisyn.synth.waldorfblofeld.WaldorfBlofeld.class, 
-    edisyn.synth.waldorfblofeld.WaldorfBlofeldMulti.class, 
-    edisyn.synth.waldorfmicrowavext.WaldorfMicrowaveXT.class, 
-    edisyn.synth.waldorfmicrowavext.WaldorfMicrowaveXTMulti.class, 
-    edisyn.synth.yamahadx7.YamahaDX7.class, 
-    edisyn.synth.yamahatx81z.YamahaTX81Z.class, 
-    edisyn.synth.yamahatx81z.YamahaTX81ZMulti.class,
-    };
+    // https://www.logicbig.com/tutorials/core-java-tutorial/java-se-api/service-loader.html
+    public static final Class[] synths = ServiceLoader.load(Synth.class).stream().map(ServiceLoader.Provider::type).toArray(Class[]::new);
     
     /** All synthesizer names in Edisyn, one per class in synths */
     public static String[] getSynthNames()


### PR DESCRIPTION
This simplifies writing synth editors in other JVM languages than Java by extracting concrecte names of implementation classes from [edisyn.Synth](https://github.com/eclab/edisyn/blob/92d2529fd18fe754de3020e4cff19e4a64188758/edisyn/Synth.java#L384) into a configuration file. In theory, this should also allow the distribution of synth editor implementations independently from the main program.

I am currently writing an [edisyn editor in Clojure](https://github.com/danielappelt/edisyn-beatstep/). The fact that you have to put the concrete class name of the implementing class into its super class does not play very well in this scenario as edisyn (Java) and the concrete implementation (Clojure) are always compiled in separate steps.

For the proposed change concrete class names are put into configuration file `META-INF/services/edisyn.Synth`. The file is not (yet) part of this pull request as I am not sure where it would need to go in order to be compatible with your build system. For an example, see [the file](https://github.com/danielappelt/edisyn-beatstep/blob/master/resources/META-INF/services/edisyn.Synth) my repository.

The implementation uses [Java service provider interfaces](https://docs.oracle.com/javase/9/docs/api/java/util/ServiceLoader.html) as they are part of standard Java. Please be aware that **this raises the minimum Java version required to run edisyn** to Java version 9 as only of this version access to service providers is possible without directly instantiating them.

Implementing this feature using another (third-party) factory implementation could avoid raising the minimum Java version but would most probably need more effort at another end.