### PR TITLE
added parameter info for LFO4 and LFO5

### DIFF
--- a/edisyn/synth/asmhydrasynth/sysex/SysexPatchFormat.txt
+++ b/edisyn/synth/asmhydrasynth/sysex/SysexPatchFormat.txt
@@ -736,8 +736,8 @@ BYTE    HEX     INFO
 729     2D9     
 730     2DA     
 731     2DB     
-732     2DC     
-733     2DD     
+732     2DC     LFO 4 Wave(stays on 00- second value in difference output changes so that is byte 733 I presume)     
+733     2DD     LFO 4 Wave value range 0 - 10; waveforms are Sine, Triangle, Saw Up, Saw Down, Square, Pulse27%, Pulse13%, S&H, Noise, Random, Step (same for all LFO's)     
 734     2DE     
 735     2DF     
 736     2E0     
@@ -774,8 +774,8 @@ BYTE    HEX     INFO
 767     2FF     
 768     300     
 769     301     
-770     302     
-771     303     
+770     302     LFO 5 Wave(stays on 00- second value in difference output changes so that is byte 771 I presume)      
+771     303     LFO 5 Wave value range 0 - 10; waveforms are Sine, Triangle, Saw Up, Saw Down, Square, Pulse27%, Pulse13%, S&H, Noise, Random, Step (same for all LFO's)
 772     304     
 773     305     
 774     306     


### PR DESCRIPTION
LFO Wave names are: Sine, Triangle, Saw Up, Saw Down, Square, Pulse27%, Pulse13%, S&H, Noise, Random, Step (same for all LFO's)

LFO 5 is at 770/771 (value)
LFO 4 is at 732/733 (value)