### PR TITLE
waldorf Pulse2: fix Semitone display

### DIFF
--- a/edisyn/synth/waldorfpulse2/WaldorfPulse2.java
+++ b/edisyn/synth/waldorfpulse2/WaldorfPulse2.java
@@ -309,7 +309,7 @@ public class WaldorfPulse2 extends Synth
             hbox.add(comp);
             }
                 
-        comp = new LabelledDial("Semitone", this, "osc" + osc + "semitone", color, 16, 112);
+        comp = new LabelledDial("Semitone", this, "osc" + osc + "semitone", color, 16, 112, 64);
         hbox.add(comp);
 
         comp = new LabelledDial("Detune", this, "osc" + osc + "detune", color, 0, 127, 64);


### PR DESCRIPTION
add 'subtractForDisplay' on 'semitone' for all oscillators so it displays the same as on the device:-48 to +48

(iso the confusing 16 to 112)